### PR TITLE
Sync 4plus

### DIFF
--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(music_client
     client.cpp
     audioplayer.cpp
     peer_network.cpp
+    sync_clock.cpp
 )
 
 # Include directories

--- a/src/client/audioplayer.cpp
+++ b/src/client/audioplayer.cpp
@@ -62,7 +62,7 @@ bool AudioPlayer::loadFromMemory(const char* data, size_t size) {
     AudioComponentInstanceDispose(audioUnit);
     audioUnit = nullptr;
   }
-  
+
   if (size < sizeof(WavHeader)) {
     std::cerr << "Data too small to be a valid WAV file." << std::endl;
     return false;

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -91,11 +91,8 @@ void AudioClient::Play() {
     peer_network_->BroadcastCommand("play", player_.get_position());
     // BroadcastCommand now handles synchronization timing internally
     // and will delay until the right time to play
-  } else {
-    // Just play immediately if not broadcasting
-    LOG_INFO("Playing audio immediately (no sync)");
-    player_.play();
   }
+  player_.play();
 }
 
 void AudioClient::Pause() {
@@ -104,11 +101,8 @@ void AudioClient::Pause() {
     LOG_DEBUG("Broadcasting pause command to peers");
     peer_network_->BroadcastCommand("pause", player_.get_position());
     // BroadcastCommand now handles synchronization timing internally
-  } else {
-    // Just pause immediately if not broadcasting
-    LOG_INFO("Pausing audio immediately (no sync)");
-    player_.pause();
   }
+  player_.pause();
 }
 
 void AudioClient::Resume() {
@@ -117,11 +111,8 @@ void AudioClient::Resume() {
     LOG_DEBUG("Broadcasting resume command to peers");
     peer_network_->BroadcastCommand("resume", player_.get_position());
     // BroadcastCommand now handles synchronization timing internally
-  } else {
-    // Just resume immediately if not broadcasting
-    LOG_INFO("Resuming audio immediately (no sync)");
-    player_.resume();
   }
+  player_.resume();
 }
 
 void AudioClient::Stop() {
@@ -130,11 +121,8 @@ void AudioClient::Stop() {
     LOG_DEBUG("Broadcasting stop command to peers");
     peer_network_->BroadcastCommand("stop", 0);
     // BroadcastCommand now handles synchronization timing internally
-  } else {
-    // Just stop immediately if not broadcasting
-    LOG_INFO("Stopping audio immediately (no sync)");
-    player_.stop();
   }
+  player_.stop();
 }
 
 unsigned int AudioClient::GetPosition() const { return player_.get_position(); }

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -89,14 +89,13 @@ void AudioClient::Play() {
   if (peer_sync_enabled_ && !command_from_broadcast_ && peer_network_) {
     LOG_DEBUG("Broadcasting play command to peers");
     peer_network_->BroadcastCommand("play", player_.get_position());
+    // BroadcastCommand now handles synchronization timing internally
+    // and will delay until the right time to play
+  } else {
+    // Just play immediately if not broadcasting
+    LOG_INFO("Playing audio immediately (no sync)");
+    player_.play();
   }
-
-  // Wait the amount of time
-  // Wait the amount of time
-  int wait_time = peer_network_->GetConnectedPeers().size() * 10;
-  std::this_thread::sleep_for(std::chrono::nanoseconds(wait_time));
-  LOG_INFO("Playing audio after {} ns", wait_time);
-  player_.play();
 }
 
 void AudioClient::Pause() {
@@ -104,13 +103,12 @@ void AudioClient::Pause() {
   if (peer_sync_enabled_ && !command_from_broadcast_ && peer_network_) {
     LOG_DEBUG("Broadcasting pause command to peers");
     peer_network_->BroadcastCommand("pause", player_.get_position());
+    // BroadcastCommand now handles synchronization timing internally
+  } else {
+    // Just pause immediately if not broadcasting
+    LOG_INFO("Pausing audio immediately (no sync)");
+    player_.pause();
   }
-
-  // Wait the amount of time
-  int wait_time = peer_network_->GetConnectedPeers().size() * 10;
-  std::this_thread::sleep_for(std::chrono::nanoseconds(wait_time));
-  LOG_INFO("Pausing audio");
-  player_.pause();
 }
 
 void AudioClient::Resume() {
@@ -118,13 +116,12 @@ void AudioClient::Resume() {
   if (peer_sync_enabled_ && !command_from_broadcast_ && peer_network_) {
     LOG_DEBUG("Broadcasting resume command to peers");
     peer_network_->BroadcastCommand("resume", player_.get_position());
+    // BroadcastCommand now handles synchronization timing internally
+  } else {
+    // Just resume immediately if not broadcasting
+    LOG_INFO("Resuming audio immediately (no sync)");
+    player_.resume();
   }
-
-  // Wait the amount of time
-  int wait_time = peer_network_->GetConnectedPeers().size() * 10;
-  std::this_thread::sleep_for(std::chrono::nanoseconds(wait_time));
-  LOG_INFO("Resuming audio");
-  player_.resume();
 }
 
 void AudioClient::Stop() {
@@ -132,13 +129,12 @@ void AudioClient::Stop() {
   if (peer_sync_enabled_ && !command_from_broadcast_ && peer_network_) {
     LOG_DEBUG("Broadcasting stop command to peers");
     peer_network_->BroadcastCommand("stop", 0);
+    // BroadcastCommand now handles synchronization timing internally
+  } else {
+    // Just stop immediately if not broadcasting
+    LOG_INFO("Stopping audio immediately (no sync)");
+    player_.stop();
   }
-
-  // Wait the amount of time
-  int wait_time = peer_network_->GetConnectedPeers().size() * 10;
-  std::this_thread::sleep_for(std::chrono::nanoseconds(wait_time));
-  LOG_INFO("Stopping audio");
-  player_.stop();
 }
 
 unsigned int AudioClient::GetPosition() const { return player_.get_position(); }

--- a/src/client/include/client.h
+++ b/src/client/include/client.h
@@ -71,6 +71,7 @@ class AudioClient {
   std::unique_ptr<audio_service::audio_service::Stub> stub_;
   AudioPlayer player_;
   std::vector<char> audio_data_;
+  int current_song_num_{-1};  // index of last loaded song
 
   // Peer synchronization
   std::shared_ptr<PeerNetwork> peer_network_;

--- a/src/client/include/peer_network.h
+++ b/src/client/include/peer_network.h
@@ -24,8 +24,8 @@ class PeerService final : public client::ClientHandler::Service {
                     client::PingResponse* response) override;
 
   grpc::Status Gossip(grpc::ServerContext* context,
-                    const client::GossipRequest* request,
-                    client::GossipResponse* response) override;
+                      const client::GossipRequest* request,
+                      client::GossipResponse* response) override;
 
   grpc::Status SendMusicCommand(grpc::ServerContext* context,
                                 const client::MusicRequest* request,
@@ -93,6 +93,6 @@ class PeerNetwork {
   std::map<std::string, std::unique_ptr<client::ClientHandler::Stub>>
       peer_stubs_;
   mutable std::mutex peers_mutex_;
-  mutable float rtt_;  // Maximum round-trip time for ping
+  mutable float rtt_;         // Maximum round-trip time for ping
   mutable float avg_offset_;  // Average offset from peers
 };

--- a/src/client/include/peer_network.h
+++ b/src/client/include/peer_network.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "audio_sync.grpc.pb.h"
+#include "sync_clock.h"
 
 // Forward declaration
 class AudioClient;
@@ -70,13 +71,17 @@ class PeerNetwork {
   float CalculateAverageOffset() const;
 
   // Get the average offset from peers
-  float GetAverageOffset() const { return avg_offset_; }
+  float GetAverageOffset() const { return sync_clock_.GetAverageOffset(); }
 
   // Broadcast a command to all connected peers
   void BroadcastCommand(const std::string& action, int position);
 
   // Broadcast gossip to all connected peers
   void BroadcastGossip();
+
+  // Get the sync clock instance
+  SyncClock& GetSyncClock() { return sync_clock_; }
+  const SyncClock& GetSyncClock() const { return sync_clock_; }
 
  private:
   // Main client reference
@@ -93,6 +98,7 @@ class PeerNetwork {
   std::map<std::string, std::unique_ptr<client::ClientHandler::Stub>>
       peer_stubs_;
   mutable std::mutex peers_mutex_;
-  mutable float rtt_;         // Maximum round-trip time for ping
-  mutable float avg_offset_;  // Average offset from peers
+
+  // Sync clock for time synchronization
+  SyncClock sync_clock_;
 };

--- a/src/client/include/peer_network.h
+++ b/src/client/include/peer_network.h
@@ -79,6 +79,9 @@ class PeerNetwork {
   // Broadcast gossip to all connected peers
   void BroadcastGossip();
 
+  // Broadcast a load command synchronously and wait for all peers to load
+  bool BroadcastLoad(int song_num);
+
   // Get the sync clock instance
   SyncClock& GetSyncClock() { return sync_clock_; }
   const SyncClock& GetSyncClock() const { return sync_clock_; }

--- a/src/client/include/sync_clock.h
+++ b/src/client/include/sync_clock.h
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <chrono>
+#include <functional>
+#include <mutex>
+#include <vector>
+
+// Forward declarations
+namespace client {
+class PingResponse;
+}
+
+// Type for time measurement functions
+using TimePointNs = int64_t;
+
+/**
+ * @class SyncClock
+ * @brief Class to handle NTP-style clock synchronization between peers
+ *
+ * This class implements clock synchronization logic based on NTP principles
+ * to allow multiple clients to coordinate timing for synchronized playback.
+ */
+class SyncClock {
+ public:
+  SyncClock();
+  ~SyncClock() = default;
+
+  /**
+   * @brief Process a ping response to calculate clock offset and RTT
+   *
+   * @param t0 Time at client before sending request (ns)
+   * @param t3 Time at client after receiving response (ns)
+   * @param response The ping response containing t1 and t2 times
+   * @return A pair of (offset, rtt) values in nanoseconds
+   */
+  std::pair<float, float> ProcessPingResponse(
+      TimePointNs t0, TimePointNs t3, const client::PingResponse& response);
+
+  /**
+   * @brief Calculate the average clock offset based on recent measurements
+   *
+   * @param offsets Vector of clock offset measurements
+   * @return The average offset in nanoseconds
+   */
+  float CalculateAverageOffset(const std::vector<float>& offsets);
+
+  /**
+   * @brief Get the current stored average offset
+   *
+   * @return The average offset in nanoseconds
+   */
+  float GetAverageOffset() const;
+
+  /**
+   * @brief Set the average offset directly
+   *
+   * @param offset The offset to set in nanoseconds
+   */
+  void SetAverageOffset(float offset);
+
+  /**
+   * @brief Get the maximum RTT observed
+   *
+   * @return The maximum RTT in nanoseconds
+   */
+  float GetMaxRtt() const;
+
+  /**
+   * @brief Set the maximum RTT directly
+   *
+   * @param rtt The RTT to set in nanoseconds
+   */
+  void SetMaxRtt(float rtt);
+
+  /**
+   * @brief Calculate a target execution time in the future
+   *
+   * This function calculates a time in the future that accounts for
+   * network delay and processing time, ensuring all peers can execute
+   * a command at approximately the same time.
+   *
+   * @param safety_margin_ns Additional safety margin in nanoseconds
+   * @return The target execution time in nanoseconds since epoch
+   */
+  TimePointNs CalculateTargetExecutionTime(float safety_margin_ns = 1000000.0f);
+
+  /**
+   * @brief Get the current time in nanoseconds since epoch
+   *
+   * @return The current time in nanoseconds
+   */
+  static TimePointNs GetCurrentTimeNs();
+
+  /**
+   * @brief Sleep until a specific target time
+   *
+   * @param target_time_ns The target time in nanoseconds since epoch
+   */
+  static void SleepUntil(TimePointNs target_time_ns);
+
+  /**
+   * @brief Adjust a target time based on clock offset
+   *
+   * @param target_time_ns The target time to adjust
+   * @param clock_offset The clock offset to apply
+   * @return The adjusted target time
+   */
+  static TimePointNs AdjustTargetTime(TimePointNs target_time_ns,
+                                      float clock_offset);
+
+ private:
+  mutable std::mutex mutex_;
+  float avg_offset_;  // Average clock offset from peers in nanoseconds
+  float max_rtt_;     // Maximum round-trip time observed in nanoseconds
+};

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -144,9 +144,7 @@ int main(int argc, char** argv) {
       }
       float average_offset = peer_network->GetAverageOffset();
       if (average_offset > 0) {
-        std::cout << "Average offset: "
-                  << average_offset << " ns"
-                  << std::endl;
+        std::cout << "Average offset: " << average_offset << " ns" << std::endl;
       } else {
         std::cout << "Average offset: NA" << std::endl;
       }

--- a/src/client/peer_network.cpp
+++ b/src/client/peer_network.cpp
@@ -129,8 +129,11 @@ grpc::Status PeerService::SendMusicCommand(grpc::ServerContext* context,
       client->Play();
     else if (action == "pause")
       client->Pause();
-    else if (action == "resume")
+    else if (action == "resume") {
+      // Reset to broadcaster's position to prevent drift
+      client->GetPlayer().set_position(position);
       client->Resume();
+    }
     else if (action == "stop")
       client->Stop();
     else

--- a/src/client/sync_clock.cpp
+++ b/src/client/sync_clock.cpp
@@ -1,0 +1,129 @@
+#include "include/sync_clock.h"
+
+#include <algorithm>
+#include <numeric>
+#include <thread>
+
+#include "../common/include/logger.h"
+#include "audio_sync.pb.h"
+
+SyncClock::SyncClock() : avg_offset_(0.0f), max_rtt_(0.0f) {
+  LOG_DEBUG("SyncClock initialized");
+}
+
+std::pair<float, float> SyncClock::ProcessPingResponse(
+    TimePointNs t0, TimePointNs t3, const client::PingResponse& response) {
+  // Get t1, t2 from response (times at the server)
+  TimePointNs t1 = response.t1();
+  TimePointNs t2 = response.t2();
+
+  // Calculate round-trip time: (t3-t0) - (t2-t1)
+  // Total time - server processing time
+  float current_rtt = static_cast<float>((t3 - t0) - (t2 - t1));
+
+  // Calculate clock offset: ((t1-t0) + (t2-t3))/2
+  // Estimate how much the client clock differs from the server
+  float current_offset = static_cast<float>((t1 - t0) + (t2 - t3)) / 2.0f;
+
+  LOG_DEBUG("Ping response: RTT={} ns, Offset={} ns", current_rtt,
+            current_offset);
+
+  return {current_offset, current_rtt};
+}
+
+float SyncClock::CalculateAverageOffset(const std::vector<float>& offsets) {
+  if (offsets.empty()) {
+    LOG_DEBUG("No offsets to calculate average from");
+    return 0.0f;
+  }
+
+  // Calculate the average offset
+  float average =
+      std::accumulate(offsets.begin(), offsets.end(), 0.0f) / offsets.size();
+
+  // Update the stored average
+  SetAverageOffset(average);
+
+  LOG_INFO("Calculated average offset: {} ns from {} measurements", average,
+           offsets.size());
+
+  return average;
+}
+
+float SyncClock::GetAverageOffset() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return avg_offset_;
+}
+
+void SyncClock::SetAverageOffset(float offset) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  avg_offset_ = offset;
+  LOG_DEBUG("Set average offset to {} ns", offset);
+}
+
+float SyncClock::GetMaxRtt() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return max_rtt_;
+}
+
+void SyncClock::SetMaxRtt(float rtt) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  max_rtt_ = rtt;
+  LOG_DEBUG("Set max RTT to {} ns", rtt);
+}
+
+TimePointNs SyncClock::CalculateTargetExecutionTime(float safety_margin_ns) {
+  // Calculate the target execution time in the future
+  // We want all peers to execute this command at approximately the same time
+  float total_margin = GetMaxRtt() + safety_margin_ns;
+
+  auto now = std::chrono::high_resolution_clock::now();
+  auto target_time =
+      now + std::chrono::nanoseconds(static_cast<int64_t>(total_margin));
+
+  // Convert to nanoseconds since epoch
+  auto target_time_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                            target_time.time_since_epoch())
+                            .count();
+
+  LOG_DEBUG("Calculated target execution time: {} ns (current time + {} ns)",
+            target_time_ns, total_margin);
+
+  return target_time_ns;
+}
+
+TimePointNs SyncClock::GetCurrentTimeNs() {
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+             std::chrono::high_resolution_clock::now().time_since_epoch())
+      .count();
+}
+
+void SyncClock::SleepUntil(TimePointNs target_time_ns) {
+  auto current_time_ns = GetCurrentTimeNs();
+
+  if (target_time_ns > current_time_ns) {
+    // Convert target time from nanoseconds to a timepoint
+    auto target_timepoint = std::chrono::high_resolution_clock::time_point(
+        std::chrono::nanoseconds(target_time_ns));
+
+    LOG_DEBUG("Sleeping until target time: {} ns (waiting {} ns)",
+              target_time_ns, target_time_ns - current_time_ns);
+
+    // Sleep until the target time
+    std::this_thread::sleep_until(target_timepoint);
+  } else {
+    LOG_DEBUG("Target time already passed, no sleep needed");
+  }
+}
+
+TimePointNs SyncClock::AdjustTargetTime(TimePointNs target_time_ns,
+                                        float clock_offset) {
+  // Adjust the target time based on our clock offset
+  TimePointNs adjusted_time =
+      target_time_ns - static_cast<TimePointNs>(clock_offset);
+
+  LOG_DEBUG("Adjusted target time from {} to {} (offset: {})", target_time_ns,
+            adjusted_time, clock_offset);
+
+  return adjusted_time;
+}

--- a/src/proto/audio_sync.proto
+++ b/src/proto/audio_sync.proto
@@ -17,10 +17,11 @@ message PingResponse {
 
 // Messages for music control
 message MusicRequest {
-  string action = 1;       // "play", "pause", "resume", "stop"
+  string action = 1;       // "play", "pause", "resume", "stop", "load"
   int64 wall_clock_ns = 2; // wall clock time in nanoseconds since epoch
   int64 wait_time_ms = 3;  // wait time in milliseconds
-  int32 position = 4;      // position of song
+  int32 position = 4;      // position of song playback
+  int32 song_num = 5;      // song index for load action
 }
 
 message MusicResponse {}

--- a/src/proto/audio_sync.proto
+++ b/src/proto/audio_sync.proto
@@ -18,8 +18,8 @@ message PingResponse {
 // Messages for music control
 message MusicRequest {
   string action = 1;       // "play", "pause", "resume", "stop"
-  float wall_clock = 2;    // wall clock time of action
-  float wait_time = 3;     // wait time in milliseconds
+  int64 wall_clock_ns = 2; // wall clock time in nanoseconds since epoch
+  int64 wait_time_ms = 3;  // wait time in milliseconds
   int32 position = 4;      // position of song
 }
 

--- a/tests/client/CMakeLists.txt
+++ b/tests/client/CMakeLists.txt
@@ -20,6 +20,27 @@ add_module_test(
     ${CMAKE_SOURCE_DIR}/src/client/audioplayer.cpp
 )
 
+# SyncClock tests
+add_module_test(
+    sync_clock_test
+    ${CMAKE_CURRENT_SOURCE_DIR}/sync_clock_test.cpp
+    ${CMAKE_SOURCE_DIR}/src/client/sync_clock.cpp
+)
+
+# Add include paths for the SyncClock test
+target_include_directories(sync_clock_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/client
+    ${CMAKE_SOURCE_DIR}/src/client/include
+    ${CMAKE_SOURCE_DIR}/src/common/include
+    ${CMAKE_BINARY_DIR}/src/proto
+)
+
+# Link against needed libraries
+target_link_libraries(sync_clock_test PRIVATE
+    common
+    proto_lib
+)
+
 # Add more client tests here as needed
 # Example:
 # add_module_test(

--- a/tests/client/sync_clock_test.cpp
+++ b/tests/client/sync_clock_test.cpp
@@ -1,0 +1,144 @@
+#include "include/sync_clock.h"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <thread>
+
+#include "audio_sync.pb.h"
+
+class SyncClockTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Initialize test objects
+    sync_clock_ = std::make_unique<SyncClock>();
+  }
+
+  void TearDown() override {
+    // Clean up resources
+    sync_clock_.reset();
+  }
+
+  std::unique_ptr<SyncClock> sync_clock_;
+};
+
+// Test ProcessPingResponse function
+TEST_F(SyncClockTest, ProcessPingResponse) {
+  // Create a test ping response
+  client::PingResponse response;
+
+  // Simulate time values (in nanoseconds)
+  // t0: client sends request
+  // t1: server receives request
+  // t2: server sends response
+  // t3: client receives response
+
+  TimePointNs t0 = 1000000000;  // 1 second
+  TimePointNs t1 = 1000010000;  // 1 second + 10000 ns
+  TimePointNs t2 = 1000020000;  // 1 second + 20000 ns
+  TimePointNs t3 = 1000030000;  // 1 second + 30000 ns
+
+  // Set t1 and t2 in the response
+  response.set_t1(t1);
+  response.set_t2(t2);
+
+  // Process the response
+  auto [offset, rtt] = sync_clock_->ProcessPingResponse(t0, t3, response);
+
+  // Expected results:
+  // Round-trip time: (t3-t0) - (t2-t1) = (1000030000-1000000000) -
+  // (1000020000-1000010000) = 30000 - 10000 = 20000 ns Clock offset: ((t1-t0) +
+  // (t2-t3))/2 = ((1000010000-1000000000) + (1000020000-1000030000))/2 = (10000
+  // + -10000)/2 = 0 ns
+
+  EXPECT_FLOAT_EQ(offset, 0.0f);
+  EXPECT_FLOAT_EQ(rtt, 20000.0f);
+}
+
+// Test CalculateAverageOffset function
+TEST_F(SyncClockTest, CalculateAverageOffset) {
+  // Create test offset values
+  std::vector<float> offsets = {100.0f, 200.0f, 300.0f, 400.0f, 500.0f};
+
+  // Calculate average
+  float avg = sync_clock_->CalculateAverageOffset(offsets);
+
+  // Expected average: (100 + 200 + 300 + 400 + 500) / 5 = 300
+  EXPECT_FLOAT_EQ(avg, 300.0f);
+
+  // Verify the average was stored in the SyncClock
+  EXPECT_FLOAT_EQ(sync_clock_->GetAverageOffset(), 300.0f);
+}
+
+// Test setting and getting offset and RTT
+TEST_F(SyncClockTest, SetAndGetOffsetAndRtt) {
+  // Set values
+  sync_clock_->SetAverageOffset(123.456f);
+  sync_clock_->SetMaxRtt(789.012f);
+
+  // Verify values
+  EXPECT_FLOAT_EQ(sync_clock_->GetAverageOffset(), 123.456f);
+  EXPECT_FLOAT_EQ(sync_clock_->GetMaxRtt(), 789.012f);
+}
+
+// Test AdjustTargetTime function
+TEST_F(SyncClockTest, AdjustTargetTime) {
+  TimePointNs target_time = 2000000000;  // 2 seconds
+  float clock_offset = 500000;           // 0.5 ms
+
+  // Adjust the target time
+  TimePointNs adjusted_time =
+      SyncClock::AdjustTargetTime(target_time, clock_offset);
+
+  // Expected adjusted time: 2000000000 - 500000 = 1999500000 ns
+  EXPECT_EQ(adjusted_time, 1999500000);
+}
+
+// Test CalculateTargetExecutionTime function
+TEST_F(SyncClockTest, CalculateTargetExecutionTime) {
+  // Set a known max RTT
+  float test_rtt = 10000.0f;  // 10 μs
+  sync_clock_->SetMaxRtt(test_rtt);
+
+  // Calculate target time with a safety margin of 5000 ns (5 μs)
+  float safety_margin = 5000.0f;
+  TimePointNs target_time =
+      sync_clock_->CalculateTargetExecutionTime(safety_margin);
+
+  // The target time should be in the future, approximately current time + RTT +
+  // safety margin
+  TimePointNs current_time = SyncClock::GetCurrentTimeNs();
+  TimePointNs expected_min =
+      current_time + static_cast<TimePointNs>(test_rtt + safety_margin -
+                                              1000);  // Allow small variance
+
+  EXPECT_GT(target_time, current_time);
+  EXPECT_GE(target_time, expected_min);
+}
+
+// Test sleep functionality to make sure it sleeps approximately the right
+// amount of time
+TEST_F(SyncClockTest, SleepUntil) {
+  // Current time
+  TimePointNs current_time = SyncClock::GetCurrentTimeNs();
+
+  // Target time 10ms in the future
+  TimePointNs target_time = current_time + 10000000;  // 10ms
+
+  // Start time measurement
+  auto start = std::chrono::high_resolution_clock::now();
+
+  // Sleep until target time
+  SyncClock::SleepUntil(target_time);
+
+  // End time measurement
+  auto end = std::chrono::high_resolution_clock::now();
+
+  // Calculate actual sleep duration in nanoseconds
+  auto sleep_duration =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
+
+  // Check that we slept for at least 9ms (allowing for some system scheduling
+  // variance)
+  EXPECT_GE(sleep_duration, 9000000);
+}


### PR DESCRIPTION
This PR adds below features: 

1. Ensures the audio is loaded before play command is broadcasted to peers
2. Separates sync & ntp logic from `peer_network.cpp` (just kept for networking stuff) for testability
3. Adds unit tests for syncing & ntp logic
4. `resume` now ensures all peers resumes from same position; avoiding drifts and help with recovery once one peer crashes (close lid but not program/port) and comes back

fixes #44 
fixes #32 